### PR TITLE
fix: deduplicate linked images when href matches img src

### DIFF
--- a/commonmark.go
+++ b/commonmark.go
@@ -272,11 +272,12 @@ func (c *Converter) InitializeCommonMarkRules() []Rule {
 				}
 
 				// If the content is a markdown image whose src matches the link href,
-				// return just the image to avoid redundant nesting like [![](url)](url).
-				if m := markdownImageR.FindStringSubmatch(strings.TrimSpace(content)); m != nil {
-					if m[2] == href {
-						md := strings.TrimSpace(content)
-						md = AddSpaceIfNessesary(selec, md)
+				// and the link has no title, return just the image to avoid
+				// redundant nesting like [![](url)](url).
+				trimmed := strings.TrimSpace(content)
+				if title == "" && strings.HasPrefix(trimmed, "![") {
+					if m := markdownImageR.FindStringSubmatch(trimmed); m != nil && m[2] == href {
+						md := AddSpaceIfNessesary(selec, trimmed)
 						return AdvancedResult{Markdown: md}, false
 					}
 				}

--- a/commonmark.go
+++ b/commonmark.go
@@ -16,6 +16,7 @@ import (
 )
 
 var multipleSpacesR = regexp.MustCompile(`  +`)
+var markdownImageR = regexp.MustCompile(`^!\[([^\]]*)\]\((.+?)(?:\s+"[^"]*")?\)$`)
 
 func (c *Converter) InitializeCommonMarkRules() []Rule {
 	var multipleSpacesR = regexp.MustCompile(`  +`)
@@ -268,6 +269,16 @@ func (c *Converter) InitializeCommonMarkRules() []Rule {
 				// a link without text won't de displayed anyway
 				if content == "" {
 					return AdvancedResult{}, true
+				}
+
+				// If the content is a markdown image whose src matches the link href,
+				// return just the image to avoid redundant nesting like [![](url)](url).
+				if m := markdownImageR.FindStringSubmatch(strings.TrimSpace(content)); m != nil {
+					if m[2] == href {
+						md := strings.TrimSpace(content)
+						md = AddSpaceIfNessesary(selec, md)
+						return AdvancedResult{Markdown: md}, false
+					}
 				}
 
 				if opt.LinkStyle == "inlined" {

--- a/testdata/TestCommonmark/image/goldmark.golden
+++ b/testdata/TestCommonmark/image/goldmark.golden
@@ -7,4 +7,5 @@
 <p><img src="data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7" alt="star"></p>
 <p><img src="http://commonmark.org/help/images/favicon.png" alt="website favicon"></p>
 <p><img src="http://commonmark.org/help/images/favicon.png" alt="website favicon"></p>
+<p><a href="http://commonmark.org/help/images/favicon.png" title="Click to enlarge"><img src="http://commonmark.org/help/images/favicon.png" alt="website favicon"></a></p>
 <p><a href="http://commonmark.org/"><img src="http://commonmark.org/help/images/favicon.png" alt="website favicon"></a></p>

--- a/testdata/TestCommonmark/image/goldmark.golden
+++ b/testdata/TestCommonmark/image/goldmark.golden
@@ -6,3 +6,5 @@
 <p>zzz)</p>
 <p><img src="data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7" alt="star"></p>
 <p><img src="http://commonmark.org/help/images/favicon.png" alt="website favicon"></p>
+<p><img src="http://commonmark.org/help/images/favicon.png" alt="website favicon"></p>
+<p><a href="http://commonmark.org/"><img src="http://commonmark.org/help/images/favicon.png" alt="website favicon"></a></p>

--- a/testdata/TestCommonmark/image/input.html
+++ b/testdata/TestCommonmark/image/input.html
@@ -56,6 +56,14 @@ zzz' />
 </p>
 
 
+<!--image inside a link with same href but link has a title-->
+<p>
+<a href="http://commonmark.org/help/images/favicon.png" title="Click to enlarge">
+    <img alt="website favicon" src="http://commonmark.org/help/images/favicon.png" />
+</a>
+</p>
+
+
 <!--image inside a link with a different href-->
 <p>
 <a href="http://commonmark.org/">

--- a/testdata/TestCommonmark/image/input.html
+++ b/testdata/TestCommonmark/image/input.html
@@ -48,3 +48,19 @@ zzz' />
 </a>
 
 
+<!--image inside a link with the same href as src-->
+<p>
+<a href="http://commonmark.org/help/images/favicon.png">
+    <img alt="website favicon" src="http://commonmark.org/help/images/favicon.png" />
+</a>
+</p>
+
+
+<!--image inside a link with a different href-->
+<p>
+<a href="http://commonmark.org/">
+    <img alt="website favicon" src="http://commonmark.org/help/images/favicon.png" />
+</a>
+</p>
+
+

--- a/testdata/TestCommonmark/image/output.default.golden
+++ b/testdata/TestCommonmark/image/output.default.golden
@@ -16,4 +16,6 @@ zzz)
 
 ![website favicon](http://commonmark.org/help/images/favicon.png)
 
+[![website favicon](http://commonmark.org/help/images/favicon.png)](http://commonmark.org/help/images/favicon.png "Click to enlarge")
+
 [![website favicon](http://commonmark.org/help/images/favicon.png)](http://commonmark.org/)

--- a/testdata/TestCommonmark/image/output.default.golden
+++ b/testdata/TestCommonmark/image/output.default.golden
@@ -13,3 +13,7 @@ zzz)
 ![star](data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7)
 
 ![website favicon](http://commonmark.org/help/images/favicon.png)
+
+![website favicon](http://commonmark.org/help/images/favicon.png)
+
+[![website favicon](http://commonmark.org/help/images/favicon.png)](http://commonmark.org/)


### PR DESCRIPTION
## Summary
- When `<a>` wraps an `<img>` and both point to the same URL, return just the image markdown instead of nesting `[![](url)](url)`

Fixes: https://github.com/firecrawl/firecrawl/issues/2971
ENG-4543