### PR TITLE
fix: collapse multiline link content to spaces

### DIFF
--- a/testdata/TestCommonmark/link/output.inlined.golden
+++ b/testdata/TestCommonmark/link/output.inlined.golden
@@ -10,13 +10,9 @@
 
 [Broken Link](http://broken.com/test.html%5Cr)
 
-[First Text\
-![](http://example.com/xxx)\
-Second Text](http://multi.org/)
+[First Text ![](http://example.com/xxx) Second Text](http://multi.org/)
 
-- [First Text\
-  \
-  Second Text](http://list.org/)
+- [First Text Second Text](http://list.org/)
 
 [GitHub](https://github.com "GitHub")
 
@@ -30,8 +26,4 @@ Before [close](http://example_close.com) After
 
 [DIW-Chef zum Grünen-Programm "Vermögenssteuer ist aus wirtschaftlicher Sicht klug"](http://example.com/page.html "\"Vermögenssteuer ist aus wirtschaftlicher Sicht klug\"")
 
-[**Die App WDR aktuell begleitet Sie durch den Tag**\
-\
- Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.\
-  \| \
- **mehr**](http://example.com/nachrichten/wdr-aktuell-app-stores-100.html "Die App WDR aktuell begleitet Sie durch den Tag ")
+[**Die App WDR aktuell begleitet Sie durch den Tag**  Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.   \|   **mehr**](http://example.com/nachrichten/wdr-aktuell-app-stores-100.html "Die App WDR aktuell begleitet Sie durch den Tag ")

--- a/testdata/TestCommonmark/link/output.referenced_collapsed.golden
+++ b/testdata/TestCommonmark/link/output.referenced_collapsed.golden
@@ -10,13 +10,9 @@
 
 [Broken Link][]
 
-[First Text\
-![](http://example.com/xxx)\
-Second Text][]
+[First Text ![](http://example.com/xxx) Second Text][]
 
-- [First Text\
-  \
-  Second Text][]
+- [First Text Second Text][]
 
 [GitHub][]
 
@@ -30,11 +26,7 @@ Before [close][] After
 
 [DIW-Chef zum Grünen-Programm "Vermögenssteuer ist aus wirtschaftlicher Sicht klug"][]
 
-[**Die App WDR aktuell begleitet Sie durch den Tag**\
-\
- Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.\
-  \| \
- **mehr**][]
+[**Die App WDR aktuell begleitet Sie durch den Tag**  Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.   \|   **mehr**][]
 
 [Simple Absolute Link]: http://simple.org/
 [Simple Relative Link]: http://example.com/page.html
@@ -42,12 +34,8 @@ Before [close][] After
 [Link with Title]: http://title.org/ "Some Title"
 [Link with multiline Title]: http://title.org/ "Some  Long Title"
 [Broken Link]: http://broken.com/test.html%5Cr
-[First Text\
-![](http://example.com/xxx)\
-Second Text]: http://multi.org/
-[First Text\
-\
-Second Text]: http://list.org/
+[First Text ![](http://example.com/xxx) Second Text]: http://multi.org/
+[First Text Second Text]: http://list.org/
 [GitHub]: https://github.com "GitHub"
 [first top]: http://first_under.com
 [second below]: http://second_under.com
@@ -56,8 +44,4 @@ Second Text]: http://list.org/
 [close]: http://example_close.com
 [**Heading A**  **Heading B**]: http://example.com/page.html
 [DIW-Chef zum Grünen-Programm "Vermögenssteuer ist aus wirtschaftlicher Sicht klug"]: http://example.com/page.html "\"Vermögenssteuer ist aus wirtschaftlicher Sicht klug\""
-[**Die App WDR aktuell begleitet Sie durch den Tag**\
-\
- Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.\
-  \| \
- **mehr**]: http://example.com/nachrichten/wdr-aktuell-app-stores-100.html "Die App WDR aktuell begleitet Sie durch den Tag "
+[**Die App WDR aktuell begleitet Sie durch den Tag**  Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.   \|   **mehr**]: http://example.com/nachrichten/wdr-aktuell-app-stores-100.html "Die App WDR aktuell begleitet Sie durch den Tag "

--- a/testdata/TestCommonmark/link/output.referenced_full.golden
+++ b/testdata/TestCommonmark/link/output.referenced_full.golden
@@ -10,13 +10,9 @@
 
 [Broken Link][6]
 
-[First Text\
-![](http://example.com/xxx)\
-Second Text][7]
+[First Text ![](http://example.com/xxx) Second Text][7]
 
-- [First Text\
-  \
-  Second Text][8]
+- [First Text Second Text][8]
 
 [GitHub][9]
 
@@ -30,11 +26,7 @@ Before [close][14] After
 
 [DIW-Chef zum Grünen-Programm "Vermögenssteuer ist aus wirtschaftlicher Sicht klug"][16]
 
-[**Die App WDR aktuell begleitet Sie durch den Tag**\
-\
- Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.\
-  \| \
- **mehr**][17]
+[**Die App WDR aktuell begleitet Sie durch den Tag**  Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.   \|   **mehr**][17]
 
 [1]: http://simple.org/
 [2]: http://example.com/page.html

--- a/testdata/TestCommonmark/link/output.referenced_shortcut.golden
+++ b/testdata/TestCommonmark/link/output.referenced_shortcut.golden
@@ -10,13 +10,9 @@
 
 [Broken Link]
 
-[First Text\
-![](http://example.com/xxx)\
-Second Text]
+[First Text ![](http://example.com/xxx) Second Text]
 
-- [First Text\
-  \
-  Second Text]
+- [First Text Second Text]
 
 [GitHub]
 
@@ -30,11 +26,7 @@ Before [close] After
 
 [DIW-Chef zum Grünen-Programm "Vermögenssteuer ist aus wirtschaftlicher Sicht klug"]
 
-[**Die App WDR aktuell begleitet Sie durch den Tag**\
-\
- Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.\
-  \| \
- **mehr**]
+[**Die App WDR aktuell begleitet Sie durch den Tag**  Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.   \|   **mehr**]
 
 [Simple Absolute Link]: http://simple.org/
 [Simple Relative Link]: http://example.com/page.html
@@ -42,12 +34,8 @@ Before [close] After
 [Link with Title]: http://title.org/ "Some Title"
 [Link with multiline Title]: http://title.org/ "Some  Long Title"
 [Broken Link]: http://broken.com/test.html%5Cr
-[First Text\
-![](http://example.com/xxx)\
-Second Text]: http://multi.org/
-[First Text\
-\
-Second Text]: http://list.org/
+[First Text ![](http://example.com/xxx) Second Text]: http://multi.org/
+[First Text Second Text]: http://list.org/
 [GitHub]: https://github.com "GitHub"
 [first top]: http://first_under.com
 [second below]: http://second_under.com
@@ -56,8 +44,4 @@ Second Text]: http://list.org/
 [close]: http://example_close.com
 [**Heading A**  **Heading B**]: http://example.com/page.html
 [DIW-Chef zum Grünen-Programm "Vermögenssteuer ist aus wirtschaftlicher Sicht klug"]: http://example.com/page.html "\"Vermögenssteuer ist aus wirtschaftlicher Sicht klug\""
-[**Die App WDR aktuell begleitet Sie durch den Tag**\
-\
- Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.\
-  \| \
- **mehr**]: http://example.com/nachrichten/wdr-aktuell-app-stores-100.html "Die App WDR aktuell begleitet Sie durch den Tag "
+[**Die App WDR aktuell begleitet Sie durch den Tag**  Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.   \|   **mehr**]: http://example.com/nachrichten/wdr-aktuell-app-stores-100.html "Die App WDR aktuell begleitet Sie durch den Tag "

--- a/testdata/TestCommonmark/link/output.relative.golden
+++ b/testdata/TestCommonmark/link/output.relative.golden
@@ -10,13 +10,9 @@
 
 [Broken Link](http://broken.com/test.html\r)
 
-[First Text\
-![](xxx)\
-Second Text](http://multi.org/)
+[First Text ![](xxx) Second Text](http://multi.org/)
 
-- [First Text\
-  \
-  Second Text](http://list.org/)
+- [First Text Second Text](http://list.org/)
 
 [GitHub](https://github.com "GitHub")
 
@@ -30,8 +26,4 @@ Before [close](http://example_close.com) After
 
 [DIW-Chef zum Grünen-Programm "Vermögenssteuer ist aus wirtschaftlicher Sicht klug"](/page.html "\"Vermögenssteuer ist aus wirtschaftlicher Sicht klug\"")
 
-[**Die App WDR aktuell begleitet Sie durch den Tag**\
-\
- Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.\
-  \| \
- **mehr**](/nachrichten/wdr-aktuell-app-stores-100.html "Die App WDR aktuell begleitet Sie durch den Tag ")
+[**Die App WDR aktuell begleitet Sie durch den Tag**  Sie möchten eine App, die Sie so durch den Tag in NRW begleitet, dass Sie jederzeit mitreden können? Die App WDR aktuell bietet Ihnen dafür immer die passenden Nachrichten.   \|   **mehr**](/nachrichten/wdr-aktuell-app-stores-100.html "Die App WDR aktuell begleitet Sie durch den Tag ")

--- a/testdata/TestRealWorld/golang.org/goldmark.golden
+++ b/testdata/TestRealWorld/golang.org/goldmark.golden
@@ -14,10 +14,7 @@
 <p>Hello, World!Conway's Game of LifeFibonacci ClosurePeano IntegersConcurrent piConcurrent Prime SievePeg Solitaire SolverTree Comparison</p>
 <p>Go is an open source programming language that makes it easy to build
 simple, reliable, and efficient software.</p>
-<p><a href="http://golang.org/dl/">Download Go<br>
-Binary distributions available for<br>
-<br>
-Linux, Mac OS X, Windows, and more.</a></p>
+<p><a href="http://golang.org/dl/">Download Go Binary distributions available for Linux, Mac OS X, Windows, and more.</a></p>
 <p>Featured video</p>
 <p><a href="http://www.youtube.com/embed/ytEkHepK08c">iframe</a></p>
 <p>Featured articles</p>

--- a/testdata/TestRealWorld/golang.org/output.default.golden
+++ b/testdata/TestRealWorld/golang.org/output.default.golden
@@ -28,10 +28,7 @@ Hello, World!Conway's Game of LifeFibonacci ClosurePeano IntegersConcurrent piCo
 Go is an open source programming language that makes it easy to build
 simple, reliable, and efficient software.
 
-[Download Go\
-Binary distributions available for\
-\
-Linux, Mac OS X, Windows, and more.](http://golang.org/dl/)
+[Download Go Binary distributions available for Linux, Mac OS X, Windows, and more.](http://golang.org/dl/)
 
 Featured video
 

--- a/testdata/TestRealWorld/snippets/heading_in_link/goldmark.golden
+++ b/testdata/TestRealWorld/snippets/heading_in_link/goldmark.golden
@@ -1,14 +1,1 @@
-<p><a href="http://example.com/event_jul20"><strong>#event_jul20</strong><br>
-Remote<br>
-<br>
-Datum<br>
-<br>
-31.07. - 02.08.20<br>
-<br>
-<br>
-Uhrzeit<br>
-<br>
-Fr 15 Uhr - So 19 Uhr<br>
-<br>
-<br>
-Details anzeigen →</a></p>
+<p><a href="http://example.com/event_jul20"><strong>#event_jul20</strong> Remote Datum 31.07. - 02.08.20   Uhrzeit Fr 15 Uhr - So 19 Uhr   Details anzeigen →</a></p>

--- a/testdata/TestRealWorld/snippets/heading_in_link/output.default.golden
+++ b/testdata/TestRealWorld/snippets/heading_in_link/output.default.golden
@@ -1,14 +1,1 @@
-[**\#event\_jul20**\
-Remote\
-\
-Datum\
-\
-31.07. - 02.08.20\
-\
-\
-Uhrzeit\
-\
-Fr 15 Uhr - So 19 Uhr\
-\
-\
-Details anzeigen →](http://example.com/event_jul20)
+[**\#event\_jul20** Remote Datum 31.07. - 02.08.20   Uhrzeit Fr 15 Uhr - So 19 Uhr   Details anzeigen →](http://example.com/event_jul20)

--- a/testdata/TestRealWorld/snippets/tweet/goldmark.golden
+++ b/testdata/TestRealWorld/snippets/tweet/goldmark.golden
@@ -1,8 +1,1 @@
-<p><a href="http://example.com/status/1"><img src="http://example.com/image/profile.jpg" alt="">Max Mustermann @max<br>
-<br>
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. <br>
-<img src="http://example.com/img.jpg" alt=""><br>
-<br>
-June 12th 2020<br>
-<br>
-17 Retweets93 Likes</a></p>
+<p><a href="http://example.com/status/1"><img src="http://example.com/image/profile.jpg" alt="">Max Mustermann @max Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.  <img src="http://example.com/img.jpg" alt=""> June 12th 2020 17 Retweets93 Likes</a></p>

--- a/testdata/TestRealWorld/snippets/tweet/output.default.golden
+++ b/testdata/TestRealWorld/snippets/tweet/output.default.golden
@@ -1,8 +1,1 @@
-[![](http://example.com/image/profile.jpg)Max Mustermann @max\
-\
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. \
-![](http://example.com/img.jpg)\
-\
-June 12th 2020\
-\
-17 Retweets93 Likes](http://example.com/status/1)
+[![](http://example.com/image/profile.jpg)Max Mustermann @max Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.  ![](http://example.com/img.jpg) June 12th 2020 17 Retweets93 Likes](http://example.com/status/1)

--- a/utils.go
+++ b/utils.go
@@ -218,15 +218,19 @@ func TrimTrailingSpaces(text string) string {
 	return strings.Join(parts, "\n")
 }
 
-// The same as `multipleNewLinesRegex`, but applies to escaped new lines inside a link `\n\`
-var multipleNewLinesInLinkRegex = regexp.MustCompile(`(\n\\){1,}`) // `([\n\r\s]\\)`
+// multipleNewLinesRegex but for collapsing newlines in link content
+var multipleNewLinesRegexInLink = regexp.MustCompile(`\n{2,}`)
 
-// EscapeMultiLine deals with multiline content inside a link
+// EscapeMultiLine deals with multiline content inside a link by collapsing
+// newlines into spaces. Markdown links with backslash-escaped newlines (\\\n)
+// are technically valid CommonMark but poorly supported by many renderers,
+// so we flatten the content to a single line instead.
 func EscapeMultiLine(content string) string {
 	content = strings.TrimSpace(content)
-	content = strings.Replace(content, "\n", `\`+"\n", -1)
-
-	content = multipleNewLinesInLinkRegex.ReplaceAllString(content, "\n\\")
+	// First collapse multiple newlines into a single one
+	content = multipleNewLinesRegexInLink.ReplaceAllString(content, "\n")
+	// Then replace remaining single newlines with a space
+	content = strings.Replace(content, "\n", " ", -1)
 
 	return content
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -252,7 +252,7 @@ func TestEscapeMultiLine(t *testing.T) {
 		Expect string
 	}{
 		{
-			Name: "escape new lines",
+			Name: "collapse newlines to spaces",
 			Text: `line1
 line2
 
@@ -261,18 +261,25 @@ line3
 
 
 
-
-
-
-
-
 line4`,
-			Expect: `line1\
-line2\
-\
-line3\
-\
-line4`,
+			Expect: `line1 line2 line3 line4`,
+		},
+		{
+			Name: "single newline becomes space",
+			Text: `hello
+world`,
+			Expect: `hello world`,
+		},
+		{
+			Name:   "no newlines unchanged",
+			Text:   `simple text`,
+			Expect: `simple text`,
+		},
+		{
+			Name: "trims whitespace",
+			Text: `  padded  
+`,
+			Expect: `padded`,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- `EscapeMultiLine` now collapses newlines inside link text to spaces instead of backslash-escaped newlines (`\` + newline)
- Backslash-newline inside link text is technically valid CommonMark but poorly supported by many renderers and produces ugly output
- This produces cleaner single-line link text like `[**Title** Description](url)` instead of `[**Title** \\\n\\\nDescription](url)`

## Test plan
- [x] Updated `TestEscapeMultiLine` unit tests with new expected output
- [x] Updated all golden files for link and real-world test cases
- [x] Full test suite passes (`go test ./...`)
- [x] Verified against docs.firecrawl.dev HTML — no more spurious `\` in link text